### PR TITLE
Added code to extract links from logs and convert then into hyper links.

### DIFF
--- a/htmllize.py
+++ b/htmllize.py
@@ -21,6 +21,7 @@ The name of the file is also very specific: Logs-2018-06-18-04-46.txt
 import sys
 from pathlib import Path
 from string import Template
+import re
 
 DATE_DELIM = "/"
 BASE_TEMPLATE = "logs-template.tmpl"
@@ -57,6 +58,9 @@ HTML_LOG_TEMPLATE = """\
       </tr>
 """
 
+WEB_URL_REGEX = r'(https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|www\.[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9]\.[^\s]{2,}|www\.[a-zA-Z0-9]\.[^\s]{2,})'
+WEB_URL_REP_REGEX = r'<a href="\1" target="_blank">\1</a>'
+
 
 def get_metadata(log_file_name):
     """Parse the log file name to get the data and time.
@@ -89,9 +93,13 @@ def parse_log_line(line):
     time, nick, *message = line.split(" ")
     # Strip the [ ] from the time.
     time = time[1:-1].strip()
-    # Strip the < > from the time.
+    # Strip the < > from the nick.
     nick = nick[1:-1].strip()
-    return (time, nick, " ".join(message))
+
+    message = " ".join(message)
+    message = re.sub(WEB_URL_REGEX, WEB_URL_REP_REGEX, message)
+
+    return (time, nick, message)
 
 
 def generate_html(log_file):

--- a/htmllize.py
+++ b/htmllize.py
@@ -58,7 +58,10 @@ HTML_LOG_TEMPLATE = """\
       </tr>
 """
 
-WEB_URL_REGEX = r'(https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|www\.[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9]\.[^\s]{2,}|www\.[a-zA-Z0-9]\.[^\s]{2,})'
+# Here is the link to git gist with rail road diagram for web url regex
+# https://gist.github.com/RatanShreshtha/76063f21ddbfb0335a341ce1c272170e
+
+WEB_URL_REGEX = r'(https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9][a-zA-Z0-9-]+\.[^\s]{2,}|www\.[a-zA-Z0-9][a-zA-Z0-9-]+\.[^\s]{2,}|https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9]\.[^\s]{2,}|www\.[a-zA-Z0-9]\.[^\s]{2,})'
 WEB_URL_REP_REGEX = r'<a href="\1" target="_blank">\1</a>'
 
 


### PR DESCRIPTION
This should extract links from the raw text logs and convert them into hyper links in html logs.

**Old HTML logs**

![screenshot-2018-7-2 dgplug summer training logs - 2018 06 25 1](https://user-images.githubusercontent.com/10801618/42147319-d0fc18fe-7dea-11e8-803d-3c0c8b416301.png)

**New HTML logs**

![screenshot-2018-7-2 dgplug summer training logs - 2018 06 25](https://user-images.githubusercontent.com/10801618/42147331-dba38d8c-7dea-11e8-90d7-c0fcfa740b09.png)
